### PR TITLE
Add support for statistics for 10 sensors

### DIFF
--- a/custom_components/skodaconnect/sensor.py
+++ b/custom_components/skodaconnect/sensor.py
@@ -52,3 +52,15 @@ class SkodaSensor(SkodaEntity):
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         return self.instrument.unit
+
+    @property
+    def state_class(self):
+        """Return the state_class for the sensor, to enable statistics"""
+        state_class = None
+        if self.instrument.attr in [
+            'battery_level', 'adblue_level', 'fuel_level', 'charging_time_left', 'charging_power', 'charge_rate',
+            'electric_range', 'combustion_range', 'combined_range', 'outside_temperature'
+        ]:
+            state_class = "measurement"
+        return state_class
+


### PR DESCRIPTION
Adds support for statistic collection in HASS for the following sensors:

- battery_level
- adblue_level
- fuel_level
- charging_time_left
- charging_power
- charge_rate
- electric_range
- combustion_range
- combined_range
- outside_temperature

Using these statistics will need HomeAssistant 2021.9.0+