### PR TITLE
 Signal the start of a YAML document

### DIFF
--- a/custom_components/skodaconnect/services.yaml
+++ b/custom_components/skodaconnect/services.yaml
@@ -1,5 +1,5 @@
 # Describes the format for available Skoda Connect service calls
-
+---
 set_charge_limit:
   name: Set charge limit
   description: >


### PR DESCRIPTION
I added two common best practices for YAML files:

- Document separator `---` to signal the start of the document
- A new line add the end of the document